### PR TITLE
provide API for external memory management

### DIFF
--- a/src/mruby_input_stream.c
+++ b/src/mruby_input_stream.c
@@ -68,7 +68,7 @@ mrb_mruby_input_stream_free(mrb_state *mrb, void *ptr)
   mrb_free(mrb, stream);
 }
 
-static void setup_stream(mrb_state *mrb, mrb_input_stream_t *stream, const char *base, mrb_int len, mrb_input_stream_free_callback free_cb, void *free_cb_data)
+static void setup_stream(mrb_state *mrb, mrb_input_stream_t *stream, const char *base, mrb_int len, mrb_int pos, mrb_input_stream_free_callback free_cb, void *free_cb_data)
 {
   if (free_cb == NULL) {
     if (len > 0) {
@@ -89,7 +89,7 @@ static void setup_stream(mrb_state *mrb, mrb_input_stream_t *stream, const char 
     stream->free_cb_data = free_cb_data;
   }
 
-  stream->pos = 0;
+  stream->pos = pos;
 }
 
 mrb_input_stream_t*
@@ -97,7 +97,7 @@ mrb_input_stream_create(mrb_state *mrb, const char *base, mrb_int len, mrb_input
 {
   mrb_input_stream_t *stream = (mrb_input_stream_t *)mrb_malloc(mrb, sizeof(mrb_input_stream_t));
 
-  setup_stream(mrb, stream, base, len, free_cb, free_cb_data);
+  setup_stream(mrb, stream, base, len, 0, free_cb, free_cb_data);
   return stream;
 }
 
@@ -112,13 +112,30 @@ mrb_input_stream_value(mrb_state *mrb, const char *base, mrb_int len)
 }
 
 void
-mrb_input_stream_reset(mrb_state *mrb, mrb_value self, const char *base, mrb_int len, mrb_input_stream_free_callback free_cb, void *free_cb_data)
+mrb_input_stream_get_data(mrb_state *mrb, mrb_value self, const char **base, mrb_int *len, mrb_int *pos, mrb_input_stream_free_callback *free_cb, void **free_cb_data)
+{
+  mrb_input_stream_t *stream = DATA_PTR(self);
+
+  if (base != NULL)
+    *base = stream->base;
+  if (len != NULL)
+    *len = stream->len;
+  if (pos != NULL)
+    *pos = stream->pos;
+  if (free_cb != NULL)
+    *free_cb = stream->free_cb;
+  if (free_cb_data != NULL)
+    *free_cb_data = stream->free_cb_data;
+}
+
+void
+mrb_input_stream_set_data(mrb_state *mrb, mrb_value self, const char *base, mrb_int len, mrb_int pos, mrb_input_stream_free_callback free_cb, void *free_cb_data)
 {
   mrb_input_stream_t *stream = DATA_PTR(self);
 
   if (stream->free_cb != NULL)
     stream->free_cb(mrb, stream->base, stream->len, stream->free_cb_data);
-  setup_stream(mrb, stream, base, len, free_cb, free_cb_data);
+  setup_stream(mrb, stream, base, len, pos, free_cb, free_cb_data);
 }
 
 static mrb_value

--- a/src/mruby_input_stream.h
+++ b/src/mruby_input_stream.h
@@ -11,6 +11,9 @@ mrb_value
 mrb_input_stream_value(mrb_state *mrb, const char *base, mrb_int len);
 
 void
-mrb_input_stream_reset(mrb_state *mrb, mrb_value self, const char *base, mrb_int len, mrb_input_stream_free_callback free_cb, void *free_cb_data);
+mrb_input_stream_get_data(mrb_state *mrb, mrb_value self, const char **base, mrb_int *len, mrb_int *pos, mrb_input_stream_free_callback *free_cb, void **free_cb_data);
+
+void
+mrb_input_stream_set_data(mrb_state *mrb, mrb_value self, const char *base, mrb_int len, mrb_int pos, mrb_input_stream_free_callback free_cb, void *free_cb_data);
 
 #endif /* input_stream_h */

--- a/src/mruby_input_stream.h
+++ b/src/mruby_input_stream.h
@@ -5,7 +5,12 @@
 #ifndef mruby_input_stream_h
 #define mruby_input_stream_h
 
+typedef void (*mrb_input_stream_free_callback)(mrb_state *mrb, const char *base, mrb_int len, void *cb_data);
+
 mrb_value
-mrb_input_stream_value(mrb_state *mrb, char *base, mrb_int len);
+mrb_input_stream_value(mrb_state *mrb, const char *base, mrb_int len);
+
+void
+mrb_input_stream_reset(mrb_state *mrb, mrb_value self, const char *base, mrb_int len, mrb_input_stream_free_callback free_cb, void *free_cb_data);
 
 #endif /* input_stream_h */


### PR DESCRIPTION
This PR adds API for managing the data fed using InputStream outside of the library.

In case of H2O, we use the API in the following manner:
- let InputStream refer to the request body buffer maintained by H2O, without copying the data ([mruby.c line 433](https://github.com/h2o/h2o/blob/0cd9c8d129d458fce585b6a602bd9e48fca6f5ac/lib/handler/mruby.c#L433))
- reset reference to the buffer from InputStream when request body buffer of H2O ([mruby.c line 510-514](https://github.com/h2o/h2o/blob/0cd9c8d129d458fce585b6a602bd9e48fca6f5ac/lib/handler/mruby.c#L510-L514))
- reset reference to the InputStream from H2O when the object gets GC'ed ([mruby.c line 390-395](https://github.com/h2o/h2o/blob/0cd9c8d129d458fce585b6a602bd9e48fca6f5ac/lib/handler/mruby.c#L390-L395))
