### PR TITLE
return empty string if `len` argument is not given

### DIFF
--- a/mrblib/input_stream.rb
+++ b/mrblib/input_stream.rb
@@ -9,7 +9,7 @@ class InputStream
       block.call(self.read(pos+1))
     end
     rest = self.read()
-    if rest
+    unless rest.empty?
       block.call(rest)
     end
   end

--- a/src/mruby_input_stream.c
+++ b/src/mruby_input_stream.c
@@ -206,7 +206,7 @@ mrb_input_stream_read(mrb_state *mrb, mrb_value self)
   start = stream->base + pos;
 
   if (pos >= stream->len) {
-    return mrb_nil_value();
+    return n == 0 ? mrb_str_new_lit(mrb, "") : mrb_nil_value();
   }
   if (n == 0) {
     stream->pos = stream->len;

--- a/test/input_stream.rb
+++ b/test/input_stream.rb
@@ -11,6 +11,7 @@ end
 assert('InputStream#read') do
   vec = InputStream.new("foo")
   assert_equal "foo", vec.read
+  assert_equal "", vec.read
 end
 
 assert('InputStream#read(2)') do


### PR DESCRIPTION
When reached EOF, `read()` should return an empty string, not nil.

[Rack spec](http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Input_Stream) states:
`When EOF is reached, this method returns nil if length is given and not nil, or “” if length is not given or is nil.`